### PR TITLE
FIX: when detailed track can not be read, use the one from the DB (an…

### DIFF
--- a/LTC2.Shared.SpatiaLiteRepository/Repositories/SqliteScoreRepository.cs
+++ b/LTC2.Shared.SpatiaLiteRepository/Repositories/SqliteScoreRepository.cs
@@ -328,10 +328,11 @@ namespace LTC2.Shared.SpatiaLiteRepository.Repositories
                         if (detailed)
                         {
                             var detailedTrack = TryGetDetailedTrack(athleteId, queryResult[0].tracExternalId);
-                            track.Coordinates = new List<List<double>>();
 
                             if (detailedTrack.Count > 1)
                             {
+                                track.Coordinates = new List<List<double>>();
+
                                 foreach (var coordinate in detailedTrack)
                                 {
                                     var newCoordinate = new List<double>() { coordinate[1], coordinate[0] };


### PR DESCRIPTION
…d not an empty one)